### PR TITLE
support optional, case-insensitive strings

### DIFF
--- a/source/canopy/builders/javascript.js
+++ b/source/canopy/builders/javascript.js
@@ -342,7 +342,8 @@
     },
 
     stringMatchCI_: function(expression, string) {
-      return expression + '.toLowerCase() === ' + this._quote(string) + '.toLowerCase()';
+      return expression + ' !== null && ' +
+        expression + '.toLowerCase() === ' + this._quote(string) + '.toLowerCase()';
     },
 
     regexMatch_: function(regex, string) {

--- a/source/canopy/builders/python.js
+++ b/source/canopy/builders/python.js
@@ -315,7 +315,8 @@
     },
 
     stringMatchCI_: function(expression, string) {
-      return expression + '.lower() == ' + this._quote(string) + '.lower()';
+      return expression + ' is not None and ' +
+        expression + '.lower() == ' + this._quote(string) + '.lower()';
     },
 
     regexMatch_: function(regex, string) {

--- a/source/canopy/builders/ruby.js
+++ b/source/canopy/builders/ruby.js
@@ -331,7 +331,8 @@
     },
 
     stringMatchCI_: function(expression, string) {
-      return expression + '.downcase == ' + this._quote(string) + '.downcase';
+      return '!' + expression + '.nil? && ' +
+        expression + '.downcase == ' + this._quote(string) + '.downcase';
     },
 
     regexMatch_: function(regex, string) {

--- a/spec/canopy/compiler/string_spec.js
+++ b/spec/canopy/compiler/string_spec.js
@@ -55,8 +55,11 @@ function() { with(this) {
         string2 <- `bar`')
     }})
 
-    it('fails to parse when absent', function() { with(this) {
-      assertThrows(Error, function() { CIStringTest.parse('foo') })
+    it('parses when absent', function() { with(this) {
+      assertParse( ['foo', 0, []
+                     ['foo', 0, []],
+                     ['', 3, []]],
+        CIStringTest.parse('foo') )
     }})
   }})
 }})

--- a/spec/canopy/compiler/string_spec.js
+++ b/spec/canopy/compiler/string_spec.js
@@ -46,4 +46,17 @@ function() { with(this) {
       assertParse( ['FOO', 0, []], CIStringTest.parse('FOO') )
     }})
   }})
+
+  describe('optional case-insensitive strings', function() { with(this) {
+    before(function() { with(this) {
+      Canopy.compile('grammar JS.ENV.CIStringTest \
+        root <- string1 string2? \
+        string1 <- "foo" \
+        string2 <- `bar`')
+    }})
+
+    it('fails to parse when absent', function() { with(this) {
+      assertThrows(Error, function() { CIStringTest.parse('foo') })
+    }})
+  }})
 }})


### PR DESCRIPTION
For example, in the following peg, `string2` is i) optional, and ii) case-insensitive:

```
grammar Foo                                               
  root <- string1 string2?                                      
  string1 <- "bar"                                         
  string2 <- `foo`
```

This pull request fixes this case for python and ruby as well. Not sure how these language outputs are tested so I didn't add any tests for them, only the JavaScript builder. Java seems to check for null so I didn't have to touch it.