### PR TITLE
fixed issue for single line input with errors

### DIFF
--- a/site/langs/ruby.md
+++ b/site/langs/ruby.md
@@ -125,7 +125,7 @@ class Actions
   end
 
   def make_number(input, start, _end, elements)
-    input[start..._end-1].to_i(10)
+    input[start..._end].to_i(10)
   end
 end
 

--- a/site/langs/ruby.md
+++ b/site/langs/ruby.md
@@ -125,7 +125,7 @@ class Actions
   end
 
   def make_number(input, start, _end, elements)
-    input[start..._end].to_i(10)
+    input[start..._end-1].to_i(10)
   end
 end
 

--- a/source/canopy/builders/ruby.js
+++ b/source/canopy/builders/ruby.js
@@ -136,7 +136,7 @@
 
         builder.method_('self.format_error', ['input', 'offset', 'expected'], function(builder) {
           builder._line('lines, line_no, position = input.split(/\\n/), 0, 0');
-          builder._line('while position <= offset');
+          builder._line('while position <= offset && line_no < lines.size');
           builder._indent(function(builder) {
             builder._line('position += lines[line_no].size + 1');
             builder._line('line_no += 1');


### PR DESCRIPTION
Hi James,

I've hit this issue a bunch of times when I'm testing simple productions in ruby.  Maybe it's just my environment, but this fix avoids a null reference in the loop for single line inputs.

All the tests seem to pass still, and the generated code fixes my issue.

Have a look and see what you think.

Cheers,

ast
