### PR TITLE
Show comment syntax

### DIFF
--- a/site/grammars.md
+++ b/site/grammars.md
@@ -18,6 +18,8 @@ A rule name can be any valid ASCII JavaScript variable name. The first rule in
 the grammar is the *root*; a document must match this rule to be parsed
 correctly.
 
+Lines starting with `#` are treated as comments.
+
 The details of types of expressions you can use within grammar rules are covered
 in detail in the other articles linked on the left.
 
@@ -25,6 +27,14 @@ For example, here's a simple grammar that matches any sequence of digits:
 
 ###### digits.peg
 
+    # A grammar file to be used with Canopy:
+    # https://www.npmjs.com/package/canopy
+    #
+    # Explanation and syntax reference: http://canopy.jcoglan.com/
+    #
+    # To build:
+    # `npm install -g canopy`
+    # `canopy digits.peg --lang javascript` (or java | python | ruby)
     grammar Digits
       digits  <-  [0-9]*
 


### PR DESCRIPTION
I just started a project that included a generated parser and (as I discovered later) the `.peg` file that created it.

I *really* would have loved to see comments at the top of the `.peg` file, and also at the top of the generated parser saying "hey, this wasn't hand-written, go look at the `.peg` file".

This PR just updates the docs to show how one can add comments to the `.peg` file and an example of a helpful comment.