### PR TITLE
Add support for specifying output location

### DIFF
--- a/bin/canopy
+++ b/bin/canopy
@@ -14,7 +14,8 @@ BUILDERS.py = BUILDERS.python     = canopy.builders.python;
 BUILDERS.rb = BUILDERS.ruby       = canopy.builders.ruby;
 
 try {
-  var options   = nopt({lang: String}, {l: '--lang'}),
+  var options   = nopt({lang: String, out: String}, 
+  			{l: '--lang', o: '--out'}),
       lang      = options.lang || 'js',
       inputFile = options.argv.remain[0];
 
@@ -28,10 +29,15 @@ try {
 
   var write = function(index) {
     var name = names[index];
+    var outf = name;
     if (!name) return;
 
-    mkdirp(path.dirname(name), function(error) {
-      fs.writeFileSync(name, parser[name]);
+    if (options.out) {
+      outf = options.out;
+    }
+
+    mkdirp(path.dirname(outf), function(error) {
+      fs.writeFileSync(outf, parser[name]);
       write(index + 1);
     });
   };

--- a/src/builders/javascript.js
+++ b/src/builders/javascript.js
@@ -16,10 +16,9 @@ var Builder = function(parent, name, parentName) {
   this._varIndex = {};
 };
 
-Builder.create = function(filename, output) {
+Builder.create = function(filename) {
   var builder = new Builder();
   builder.filename = filename;
-  builder.output = output || this.filename.replace(/\.peg$/, '.js');
   return builder;
 };
 
@@ -31,7 +30,7 @@ util.assign(Builder.prototype, {
   },
 
   _outputPathname: function() {
-    return this.output;
+    return this.filename.replace(/\.peg$/, '.js');
   },
 
   _write: function(string) {

--- a/src/builders/javascript.js
+++ b/src/builders/javascript.js
@@ -16,9 +16,10 @@ var Builder = function(parent, name, parentName) {
   this._varIndex = {};
 };
 
-Builder.create = function(filename) {
+Builder.create = function(filename, output) {
   var builder = new Builder();
   builder.filename = filename;
+  builder.output = output || this.filename.replace(/\.peg$/, '.js');
   return builder;
 };
 
@@ -30,7 +31,7 @@ util.assign(Builder.prototype, {
   },
 
   _outputPathname: function() {
-    return this.filename.replace(/\.peg$/, '.js');
+    return this.output;
   },
 
   _write: function(string) {


### PR DESCRIPTION
I have a project where I want to split the grammar and the output files to better manage multiple language implementations.  Currently, canopy doesn't support this option.  I added it.

Hopefully, this change or something like it will make it in a future release.  It really makes a difference in structuring your projects.

Feel free to ignore the builder bogus checkin.  That was a mistake.