### PR TITLE
Fix Action interface & string out-of-range errors.

### DIFF
--- a/src/ast/grammar.js
+++ b/src/ast/grammar.js
@@ -27,7 +27,9 @@ util.assign(Grammar.prototype, {
     builder.package_(this._name, function(builder) {
       var actions = [];
       scan(this, function(node) {
-        if (node.action_tag) actions.push(node.action_tag.identifier.text);
+        if (node._actionName) {
+          actions.push(node._actionName);
+        }
       });
 
       var nodeClassName = builder.syntaxNodeClass_(), subclassIndex = 1;

--- a/src/builders/java.js
+++ b/src/builders/java.js
@@ -384,7 +384,9 @@ util.assign(Builder.prototype, {
   chunk_: function(length) {
     var chunk = this.localVar_('chunk', this.null_()), input = 'input', of = 'offset';
     this.if_(of + ' < inputSize', function(builder) {
-      builder._line(chunk + ' = ' + input + '.substring(' + of + ', ' + of + ' + ' + length + ')');
+      builder._line(chunk + ' = ' + input + '.substring(' + of + ', ' +
+          'Math.min(' + of + ' + ' + length + ', ' +
+          input + '.length()' + '))');
     });
     return chunk;
   },


### PR DESCRIPTION
Fix a bug resulting in query actions not being added to the Actions interface.
Fix another bug which results in Java 'String index out of range'.