### PR TITLE
Run `make` during `prepare` phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 , "dependencies"    : {"mkdirp": "", "nopt": ""}
 , "devDependencies" : {"benchmark": "", "jstest": "", "pegjs": ""}
 
-, "scripts"         : {"test": "make test"}
+, "scripts"         : {"test": "make test", "prepare": "make"}
 
 , "bugs"            : {"url": "https://github.com/jcoglan/canopy/issues"}
 


### PR DESCRIPTION
Currently is not possible to install package via `npm install -g
jcoglan/canopy` because `lib/` folders is not generated by npm install. It makes
the installation of current master is not trivial process especially when version
deployed to npm is broken due to `StringIndexOutOfBoundsException` and
only master version works fine.

This PR adds `make` to `prepare` phase and adds ability to install package directly from github.
