### PR TITLE
Restrict Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 , "bin"             : {"canopy": "./bin/canopy"}
 , "preferGlobal"    : true
 , "dependencies"    : {"mkdirp": "^0.5.1", "nopt": "^4.0.1"}
-, "devDependencies" : {"benchmark": "", "jstest": "", "pegjs": ""}
+, "devDependencies" : {"benchmark": "^2.1.4", "jstest": "^1.0.5", "pegjs": "^0.10.0"}
 
 , "scripts"         : {"test": "make test"}
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 , "keywords"        : ["parser", "compiler", "peg"]
 , "license"         : "GPL-3.0"
 
-, "version"         : "0.3.0"
+, "version"         : "0.3.1"
 , "engines"         : {"node": ">=0.4.0"}
 , "main"            : "./lib/canopy.js"
 , "bin"             : {"canopy": "./bin/canopy"}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 , "main"            : "./lib/canopy.js"
 , "bin"             : {"canopy": "./bin/canopy"}
 , "preferGlobal"    : true
-, "dependencies"    : {"mkdirp": "", "nopt": ""}
+, "dependencies"    : {"mkdirp": "^0.5.1", "nopt": "^4.0.1"}
 , "devDependencies" : {"benchmark": "", "jstest": "", "pegjs": ""}
 
 , "scripts"         : {"test": "make test"}


### PR DESCRIPTION
The latest version of the mkdirp dependency (1.0.3) causes a `invalid options argument` when running the cli with something like `canopy test.peg`.  

This PR will lock the dependency to the latest working versions I was able to find on my machine. It seems that only mkdirp is the problem though.