### PR TITLE
Update mkdirp to v3.0 and fix breaking change in require('mkdirp').

### DIFF
--- a/bin/canopy
+++ b/bin/canopy
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const fs     = require('fs')
-const mkdirp = require('mkdirp')
-const nopt   = require('nopt')
+const fs         = require('fs')
+const { mkdirp } = require('mkdirp')
+const nopt       = require('nopt')
 
 const { basename, dirname, join, relative } = require('path')
 const canopy = require('../lib/canopy')

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 , "main"            : "./lib/canopy.js"
 , "bin"             : { "canopy": "./bin/canopy" }
 
-, "dependencies"    : { "handlebars": ">=4.0.0", "mkdirp": ">=1.0.0", "nopt": "*" }
+, "dependencies"    : { "handlebars": ">=4.0.0", "mkdirp": ">=3.0.0", "nopt": "*" }
 , "devDependencies" : { "benchmark": "", "jstest": "", "pegjs": "" }
 
 , "bugs"            : { "url": "https://github.com/jcoglan/canopy/issues" }


### PR DESCRIPTION
Recent mkdirp updates broke canopy.

`TypeError: mkdirp is not a function
    at main (/Users/keith.wonderly/.nvm/versions/node/v14.19.0/lib/node_modules/canopy/bin/canopy:56:11)
    at run (/Users/keith.wonderly/.nvm/versions/node/v14.19.0/lib/node_modules/canopy/bin/canopy:64:11)
    at Object.<anonymous> (/Users/keith.wonderly/.nvm/versions/node/v14.19.0/lib/node_modules/canopy/bin/canopy:72:1)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:75:12)
    at internal/main/run_main_module.js:17:47`

This PR updates dependencies to use mkdirp v3 and fixes the breaking change.