### PR TITLE
Fixes to C# branch: unit tests and code generation

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -8,13 +8,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { dotnet: 2.1.x, framework: netcoreapp2.1 }
-          - { dotnet: 2.2.x, framework: netcoreapp2.2 }
-          - { dotnet: 3.0.x, framework: netcoreapp3.0 }
-          - { dotnet: 3.1.x, framework: netcoreapp3.1 }
-          - { dotnet: 5.0.x, framework: net5.0 }
           - { dotnet: 6.0.x, framework: net6.0 }
-          - { dotnet: 7.0.x, framework: net7.0 }
+          - { dotnet: 8.0.x, framework: net8.0 }
     name: ${{ matrix.dotnet }}
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ test/cs/obj
 test/java/target
 
 .jekyll-cache
+
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.configureOnOpen": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "makefile.configureOnOpen": false
-}

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test-all: test-java test-js test-python test-ruby
 test-java: $(test_grammars:%.peg=%/Grammar.java)
 	cd test/java && mvn clean test
 
-DOTNET_SDK?=netcoreapp3.1
+DOTNET_SDK?=net6.0
 test-cs: $(test_grammars:%.peg=%/Grammar.cs)
 	cd test/cs && dotnet test --framework ${DOTNET_SDK}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Canopy
 
-Canopy is a parser compiler targeting Java, JavaScript, Python and Ruby. It
+Canopy is a parser compiler targeting C#, Java, JavaScript, Python and Ruby. It
 takes a file describing a [parsing expression grammar][1] and compiles it into a
 parser module in the target language. The generated parsers have no runtime
 dependency on Canopy itself.

--- a/src/canopy.js
+++ b/src/canopy.js
@@ -4,8 +4,8 @@ const Compiler = require('./compiler')
 
 module.exports = {
   builders: {
+    cs:         require('./builders/cs'),
     java:       require('./builders/java'),
-    cs:       require('./builders/cs'),
     javascript: require('./builders/javascript'),
     python:     require('./builders/python'),
     ruby:       require('./builders/ruby')

--- a/templates/cs/Actions.cs
+++ b/templates/cs/Actions.cs
@@ -1,10 +1,6 @@
-using System.Collections.Generic;
-using System;
-
-namespace {{namespace}} {
     public interface Actions {
     {{#each actions}}
-        public TreeNode {{this}}(String input, int start, int end, List<TreeNode> elements);
+        public TreeNode {{this}}(string input, int start, int end, List<TreeNode> elements);
     {{/each}}
     }
-}
+

--- a/templates/cs/CacheRecord.cs
+++ b/templates/cs/CacheRecord.cs
@@ -1,5 +1,3 @@
-namespace {{namespace}} {
-
     public class CacheRecord {
         public TreeNode node;
         public int tail;
@@ -9,4 +7,3 @@ namespace {{namespace}} {
             this.tail = tail;
         }
     }
-}

--- a/templates/cs/Label.cs
+++ b/templates/cs/Label.cs
@@ -1,7 +1,6 @@
-namespace {{namespace}} {
     public enum Label {
     {{#each labels}}
         {{this}}{{#unless @last}},{{/unless}}
     {{/each}}
     }
-}
+

--- a/templates/cs/ParseError.cs
+++ b/templates/cs/ParseError.cs
@@ -1,8 +1,5 @@
-using System;
-
-namespace {{namespace}} {
     public class ParseError : Exception {
-        public ParseError(String message) : base(message) {
+        public ParseError(string message) : base(message) {
         }
     }
-}
+

--- a/templates/cs/Parser.cs
+++ b/templates/cs/Parser.cs
@@ -1,30 +1,25 @@
-using System.Collections.Generic;
-using System.Collections;
-using System;
-
-namespace {{namespace}} {
     public class {{name}} : Grammar {
-        public {{name}}(String input, Actions actions) {
+        public {{name}}(string input, Actions actions) {
             this.input = input;
             this.inputSize = input.Length;
             this.actions = actions;
             this.offset = 0;
             this.cache = new Dictionary<Label, Dictionary<int, CacheRecord>>();
             this.failure = 0;
-            this.expected = new List<String[]>();
+            this.expected = new List<string[]>();
         }
 
-        public static TreeNode parse(String input, Actions actions) {
+        public static TreeNode parse(string input, Actions actions) {
             {{name}} parser = new {{name}}(input, actions);
             return parser.parse();
         }
 
-        public static TreeNode parse(String input){
+        public static TreeNode parse(string input){
             return parse(input, null);
         }
 
-        private static String formatError(String input, int offset, List<String[]> expected) {
-            String[] lines = input.Split('\n');
+        private static string formatError(string input, int offset, List<string[]> expected) {
+            string[] lines = input.Split('\n');
             int lineNo = 0, position = 0;
 
             while (position <= offset) {
@@ -32,14 +27,14 @@ namespace {{namespace}} {
                 lineNo += 1;
             }
 
-            String line = lines[lineNo - 1];
-            String message = "Line " + lineNo + ": expected one of:\n\n";
+            string line = lines[lineNo - 1];
+            string message = "Line " + lineNo + ": expected one of:\n\n";
 
-            foreach (String[] pair in expected) {
+            foreach (string[] pair in expected) {
                 message += "    - " + pair[1] + " from " + pair[0] + "\n";
             }
 
-            String number = "" + lineNo;
+            string number = "" + lineNo;
             while (number.Length < 6) number = " " + number;
             message += "\n" + number + " | " + line + "\n";
 
@@ -59,9 +54,8 @@ namespace {{namespace}} {
             }
             if (expected.Count <= 0) {
                 failure = offset;
-                expected.Add(new String[] { {{{grammar}}}, "<EOF>" });
+                expected.Add(new string[] { {{{grammar}}}, "<EOF>" });
             }
             throw new ParseError(formatError(input, failure, expected));
         }
     }
-}

--- a/templates/cs/TreeNode.cs
+++ b/templates/cs/TreeNode.cs
@@ -1,10 +1,5 @@
-using System.Collections.Generic;
-using System.Collections;
-using System;
-
-namespace {{namespace}} {
     public class {{name}} : IEnumerable<{{name}}> {
-        public String text;
+        public string text;
         public int offset;
         public List<{{name}}> elements;
 
@@ -12,7 +7,7 @@ namespace {{namespace}} {
 
         public {{name}}() : this("", -1, new List<{{name}}>(0)) {}
 
-        public {{name}}(String text, int offset, List<{{name}}> elements) {
+        public {{name}}(string text, int offset, List<{{name}}> elements) {
             this.text = text;
             this.offset = offset;
             this.elements = elements;
@@ -41,4 +36,3 @@ namespace {{namespace}} {
             return GetEnumerator();
         }
     }
-}

--- a/test/cs/canopy.csproj
+++ b/test/cs/canopy.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
@@ -12,52 +12,11 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
 
-    <Compile Include="../grammars/choices/Actions.cs" />
-    <Compile Include="../grammars/choices/CacheRecord.cs" />
-    <Compile Include="../grammars/choices/Grammar.cs" />
-    <Compile Include="../grammars/choices/Label.cs" />
-    <Compile Include="../grammars/choices/ParseError.cs" />
-    <Compile Include="../grammars/choices/TreeNode.cs" />
     <Compile Include="../grammars/choices/Choices.cs" />
-
-    <Compile Include="../grammars/node_actions/Actions.cs" />
-    <Compile Include="../grammars/node_actions/CacheRecord.cs" />
-    <Compile Include="../grammars/node_actions/Grammar.cs" />
-    <Compile Include="../grammars/node_actions/Label.cs" />
-    <Compile Include="../grammars/node_actions/ParseError.cs" />
-    <Compile Include="../grammars/node_actions/TreeNode.cs" />
     <Compile Include="../grammars/node_actions/NodeActions.cs" />
-
-    <Compile Include="../grammars/predicates/Actions.cs" />
-    <Compile Include="../grammars/predicates/CacheRecord.cs" />
-    <Compile Include="../grammars/predicates/Grammar.cs" />
-    <Compile Include="../grammars/predicates/Label.cs" />
-    <Compile Include="../grammars/predicates/ParseError.cs" />
-    <Compile Include="../grammars/predicates/TreeNode.cs" />
     <Compile Include="../grammars/predicates/Predicates.cs" />
-
-    <Compile Include="../grammars/quantifiers/Actions.cs" />
-    <Compile Include="../grammars/quantifiers/CacheRecord.cs" />
-    <Compile Include="../grammars/quantifiers/Grammar.cs" />
-    <Compile Include="../grammars/quantifiers/Label.cs" />
-    <Compile Include="../grammars/quantifiers/ParseError.cs" />
-    <Compile Include="../grammars/quantifiers/TreeNode.cs" />
     <Compile Include="../grammars/quantifiers/Quantifiers.cs" />
-
-    <Compile Include="../grammars/sequences/Actions.cs" />
-    <Compile Include="../grammars/sequences/CacheRecord.cs" />
-    <Compile Include="../grammars/sequences/Grammar.cs" />
-    <Compile Include="../grammars/sequences/Label.cs" />
-    <Compile Include="../grammars/sequences/ParseError.cs" />
-    <Compile Include="../grammars/sequences/TreeNode.cs" />
     <Compile Include="../grammars/sequences/Sequences.cs" />
-
-    <Compile Include="../grammars/terminals/Actions.cs" />
-    <Compile Include="../grammars/terminals/CacheRecord.cs" />
-    <Compile Include="../grammars/terminals/Grammar.cs" />
-    <Compile Include="../grammars/terminals/Label.cs" />
-    <Compile Include="../grammars/terminals/ParseError.cs" />
-    <Compile Include="../grammars/terminals/TreeNode.cs" />
     <Compile Include="../grammars/terminals/Terminals.cs" />
 
   </ItemGroup>


### PR DESCRIPTION
Hi! I'm glad to have found this project, this parser generator is awesome!

I wanted to contribute some improvements, in the hope that the C# variant gets finalized and merged into the main branch - it would be amazing to have C# coverage in addition to the other languages.

I see that there was an old [PR#70](https://github.com/jcoglan/canopy/pull/70), which got merged into `c-sharp` branch, but some of the desiderata were still waiting to be addressed. This pull request addresses the following:
- C# generator now creates only one file per grammar, which is compatible with C# standard practice (unlike Java which requires a file per class)
- Upgraded project files (makefile and test csproj) to .NET Core 6/8 for better multi-platform compatibility

Regarding .NET - these changes are only relevant for people running `make` and unit tests. I upgraded project and test files, because Core 6/8 are the only ones with current long-term support - older versions of .NET are now [past their end-of-life date](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core), and running them will be increasingly difficult. 

However, this is only for testing. The generated C# code is highly backwards-compatible, and I would expect it to work with .NET going back a decade or more.

**Testing:**

I ran unit tests on Ubuntu (x86) with dotnet sdks 6.0 and 8.0:

```
$ make clean test-cs
find examples -name '*.class' -o -name '*.pyc' -exec rm {} \;
find test/grammars -type f -a ! -name '*.peg' -a ! -name __init__.py -exec rm {} \;
./bin/canopy --lang cs test/grammars/choices.peg
./bin/canopy --lang cs test/grammars/extensions.peg
./bin/canopy --lang cs test/grammars/node_actions.peg
./bin/canopy --lang cs test/grammars/predicates.peg
./bin/canopy --lang cs test/grammars/quantifiers.peg
./bin/canopy --lang cs test/grammars/sequences.peg
./bin/canopy --lang cs test/grammars/terminals.peg
cd test/cs && dotnet test --framework net6.0
  Determining projects to restore...
  All projects are up-to-date for restore.
  canopy -> /home/rob/code/canopy/test/cs/bin/Debug/net6.0/canopy.dll
Test run for /home/rob/code/canopy/test/cs/bin/Debug/net6.0/canopy.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.8.0 (x64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:   127, Skipped:     0, Total:   127, Duration: 339 ms - canopy.dll (net6.0)
```

I hope this is useful in bringing this branch closer to merging with main - and please let me know if I can help with C# support!
